### PR TITLE
86c77fv4u/bug/primitive-input-invocation

### DIFF
--- a/norman_utils_external/file_utils.py
+++ b/norman_utils_external/file_utils.py
@@ -14,10 +14,8 @@ class FileUtils(metaclass=Singleton):
     def get_buffer_size(file_obj):
         if isinstance(file_obj, io.BytesIO):
             return file_obj.getbuffer().nbytes
-        if hasattr(file_obj, "fileno"):
+        elif hasattr(file_obj, "fileno"):
             return os.fstat(file_obj.fileno()).st_size
-        if isinstance(file_obj, io.BytesIO):
-            return file_obj.getbuffer().nbytes
         raise ValueError("Unsupported file object or operation")
 
     def get_file_type(self, file_path: str):

--- a/norman_utils_external/file_utils.py
+++ b/norman_utils_external/file_utils.py
@@ -12,6 +12,8 @@ class FileUtils(metaclass=Singleton):
 
     @staticmethod
     def get_buffer_size(file_obj):
+        if isinstance(file_obj, io.BytesIO):
+            return file_obj.getbuffer().nbytes
         if hasattr(file_obj, "fileno"):
             return os.fstat(file_obj.fileno()).st_size
         if isinstance(file_obj, io.BytesIO):

--- a/norman_utils_external/file_utils.py
+++ b/norman_utils_external/file_utils.py
@@ -16,7 +16,8 @@ class FileUtils(metaclass=Singleton):
             return file_obj.getbuffer().nbytes
         elif hasattr(file_obj, "fileno"):
             return os.fstat(file_obj.fileno()).st_size
-        raise ValueError("Unsupported file object or operation")
+        else:
+            raise ValueError("Unsupported file object or operation")
 
     def get_file_type(self, file_path: str):
         try:


### PR DESCRIPTION
Prioritize the io.BytesIO check because memory buffers implement the .fileno() attribute but lack a real OS file descriptor. This prevents os.fstat() from raising an UnsupportedOperation exception when handling string/primitive data.

(#86c77fv4u)