### PR TITLE
86bx11g42/fix/file-sanitizer-text-support

### DIFF
--- a/norman_utils_external/file_sanitizer.py
+++ b/norman_utils_external/file_sanitizer.py
@@ -7,8 +7,7 @@ class FileSanitizer(metaclass=Singleton):
     def __init__(self):
         self.__file_utils = FileUtils()
 
-    def sanitize(self, file_content: bytes, required_modality: str):
-        file_extension = self.__get_file_extension(file_content)
+    def sanitize(self, file_extension: str, required_modality: str):
         if file_extension not in SignatureModalityMapping.Encoding_Map:
             raise ValueError("File type is not supported.")
 
@@ -16,6 +15,3 @@ class FileSanitizer(metaclass=Singleton):
         if data_modality != required_modality:
             raise ValueError("File modality does not match the expected modality.")
 
-    def __get_file_extension(self, file_content: bytes):
-        file_type = self.__file_utils.get_file_type_from_header(file_content)
-        return file_type["data_encoding"]

--- a/norman_utils_external/file_sanitizer.py
+++ b/norman_utils_external/file_sanitizer.py
@@ -1,11 +1,13 @@
 from norman_utils_external.file_utils import FileUtils
 from norman_utils_external.signature_modality_mapping import SignatureModalityMapping
+from norman_utils_external.singleton import Singleton
 
 
-class FileSanitizer:
+class FileSanitizer(metaclass=Singleton):
+    def __init__(self):
+        self.__file_utils = FileUtils()
 
-    @classmethod
-    def sanitize(cls, file_extension: str, required_modality: str):
+    def sanitize(self, file_extension: str, required_modality: str):
         if file_extension not in SignatureModalityMapping.Encoding_Map:
             raise ValueError("File type is not supported.")
 
@@ -13,8 +15,6 @@ class FileSanitizer:
         if data_modality != required_modality:
             raise ValueError("File modality does not match the expected modality.")
 
-    @classmethod
-    def get_file_extension(cls, file_content: bytes):
-        file_utils = FileUtils()
-        file_type = file_utils.get_file_type_from_bytes(file_content)
+    def get_file_extension(self, file_content: bytes):
+        file_type = self.__file_utils.get_file_type_from_header(file_content)
         return file_type["data_encoding"]

--- a/norman_utils_external/file_sanitizer.py
+++ b/norman_utils_external/file_sanitizer.py
@@ -7,7 +7,8 @@ class FileSanitizer(metaclass=Singleton):
     def __init__(self):
         self.__file_utils = FileUtils()
 
-    def sanitize(self, file_extension: str, required_modality: str):
+    def sanitize(self, file_content: bytes, required_modality: str):
+        file_extension = self.__get_file_extension(file_content)
         if file_extension not in SignatureModalityMapping.Encoding_Map:
             raise ValueError("File type is not supported.")
 
@@ -15,6 +16,6 @@ class FileSanitizer(metaclass=Singleton):
         if data_modality != required_modality:
             raise ValueError("File modality does not match the expected modality.")
 
-    def get_file_extension(self, file_content: bytes):
+    def __get_file_extension(self, file_content: bytes):
         file_type = self.__file_utils.get_file_type_from_header(file_content)
         return file_type["data_encoding"]

--- a/norman_utils_external/file_sanitizer.py
+++ b/norman_utils_external/file_sanitizer.py
@@ -1,11 +1,8 @@
-import filetype
-
+from norman_utils_external.file_utils import FileUtils
 from norman_utils_external.signature_modality_mapping import SignatureModalityMapping
 
 
 class FileSanitizer:
-    MIN_BYTES_FOR_DETECTION = 261
-    TEXT_MODALITY = "Text"
 
     @classmethod
     def sanitize(cls, file_extension: str, required_modality: str):
@@ -17,19 +14,7 @@ class FileSanitizer:
             raise ValueError("File modality does not match the expected modality.")
 
     @classmethod
-    def get_file_extension(cls, file_content: bytes, required_modality: str = None):
-        if required_modality == cls.TEXT_MODALITY:
-            try:
-                file_content.decode('utf-8')
-                return "txt"
-            except UnicodeDecodeError:
-                raise ValueError("File content is not valid UTF-8 text.")
-
-        if len(file_content) < cls.MIN_BYTES_FOR_DETECTION:
-            raise ValueError("File content too short to validate.")
-
-        file_type = filetype.guess(file_content)
-        if file_type is None:
-            raise ValueError("Unsupported file type - no matching signature found.")
-
-        return file_type.extension
+    def get_file_extension(cls, file_content: bytes):
+        file_utils = FileUtils()
+        file_type = file_utils.get_file_type_from_bytes(file_content)
+        return file_type["data_encoding"]

--- a/norman_utils_external/file_sanitizer.py
+++ b/norman_utils_external/file_sanitizer.py
@@ -4,27 +4,32 @@ from norman_utils_external.signature_modality_mapping import SignatureModalityMa
 
 
 class FileSanitizer:
-    # The number of bytes required by filetype package for type resolving
     MIN_BYTES_FOR_DETECTION = 261
+    TEXT_MODALITY = "Text"
 
     @classmethod
     def sanitize(cls, file_extension: str, required_modality: str):
         if file_extension not in SignatureModalityMapping.Encoding_Map:
-            raise KeyError("File type is not supported.")
+            raise ValueError("File type is not supported.")
 
         data_modality = SignatureModalityMapping.Encoding_Map[file_extension]
         if data_modality != required_modality:
             raise ValueError("File modality does not match the expected modality.")
 
     @classmethod
-    def get_file_extension(cls, file_content: bytes):
+    def get_file_extension(cls, file_content: bytes, required_modality: str = None):
+        if required_modality == cls.TEXT_MODALITY:
+            try:
+                file_content.decode('utf-8')
+                return "txt"
+            except UnicodeDecodeError:
+                raise ValueError("File content is not valid UTF-8 text.")
+
         if len(file_content) < cls.MIN_BYTES_FOR_DETECTION:
             raise ValueError("File content too short to validate.")
 
         file_type = filetype.guess(file_content)
-        file_extension = file_type.extension
-
-        if file_extension is None:
+        if file_type is None:
             raise ValueError("Unsupported file type - no matching signature found.")
 
-        return file_extension
+        return file_type.extension

--- a/norman_utils_external/file_utils.py
+++ b/norman_utils_external/file_utils.py
@@ -36,23 +36,55 @@ class FileUtils(metaclass=Singleton):
             }
         return self.__get_file_type_from_header(header)
 
+    def get_file_type_from_bytes(self, content: bytes):
+        return self.__get_file_type_from_header(content)
+
     def __get_file_type_from_header(self, header: bytes):
         hex_header = header.hex()
 
-        if hex_header.startswith("494433"):
-            data_modality, data_encoding, mime_type, file_extension = "Audio", "mp3", "audio/mpeg", "mp3"
-        elif hex_header.startswith("504b0304"):
-            data_modality, data_encoding, mime_type, file_extension = "File", "bin", "application/octet-stream", "bin"  # `.pt` files have a zip header
-        elif hex_header.startswith("89504e47"):
-            data_modality, data_encoding, mime_type, file_extension = "Image", "png", "image/png", "png"
-        elif hex_header.startswith("ffd8ff"):
-            data_modality, data_encoding, mime_type, file_extension = "Image", "jpg", "image/jpeg", "jpg"
-        elif hex_header.startswith("fff1") or hex_header.startswith("fff9"):
+        # Audio (alphabetical: aac, ac3, flac, mp3, opus, vorbis, wav)
+        if hex_header.startswith("fff1") or hex_header.startswith("fff9"):  # aac
             data_modality, data_encoding, mime_type, file_extension = "Audio", "aac", "audio/aac", "aac"
-        elif hex_header.startswith("52494646") and "57415645" in hex_header:
+        elif hex_header.startswith("0b77"):  # ac3 sync word
+            data_modality, data_encoding, mime_type, file_extension = "Audio", "ac3", "audio/ac3", "ac3"
+        elif hex_header.startswith("664c6143"):  # flac - "fLaC"
+            data_modality, data_encoding, mime_type, file_extension = "Audio", "flac", "audio/flac", "flac"
+        elif hex_header.startswith("494433"):  # mp3 - ID3 tag
+            data_modality, data_encoding, mime_type, file_extension = "Audio", "mp3", "audio/mpeg", "mp3"
+        elif hex_header.startswith("4f676753") and "4f70757348656164" in hex_header:  # opus - OggS + OpusHead
+            data_modality, data_encoding, mime_type, file_extension = "Audio", "opus", "audio/opus", "opus"
+        elif hex_header.startswith("4f676753") and "01766f72626973" in hex_header:  # vorbis - OggS + \x01vorbis
+            data_modality, data_encoding, mime_type, file_extension = "Audio", "vorbis", "audio/vorbis", "ogg"
+        elif hex_header.startswith("52494646") and "57415645" in hex_header:  # wav - RIFF + WAVE
             data_modality, data_encoding, mime_type, file_extension = "Audio", "wav", "audio/wav", "wav"
-        elif hex_header.startswith("000000") and "66747970" in hex_header:
+
+        # Image (alphabetical: jpg, png, webp)
+        elif hex_header.startswith("ffd8ff"):  # jpg
+            data_modality, data_encoding, mime_type, file_extension = "Image", "jpg", "image/jpeg", "jpg"
+        elif hex_header.startswith("89504e47"):  # png
+            data_modality, data_encoding, mime_type, file_extension = "Image", "png", "image/png", "png"
+        elif hex_header.startswith("52494646") and "57454250" in hex_header:  # webp - RIFF + WEBP
+            data_modality, data_encoding, mime_type, file_extension = "Image", "webp", "image/webp", "webp"
+
+        # Video (alphabetical: avi, matroska, mov, mp4, ogg, webm)
+        elif hex_header.startswith("52494646") and "41564920" in hex_header:  # avi - RIFF + AVI
+            data_modality, data_encoding, mime_type, file_extension = "Video", "avi", "video/x-msvideo", "avi"
+        elif hex_header.startswith("1a45dfa3") and "7765626d" not in hex_header:  # matroska - EBML without webm doctype
+            data_modality, data_encoding, mime_type, file_extension = "Video", "matroska", "video/x-matroska", "mkv"
+        elif hex_header.startswith("000000") and "6674797071742020" in hex_header:  # mov - ftyp qt (QuickTime)
+            data_modality, data_encoding, mime_type, file_extension = "Video", "mov", "video/quicktime", "mov"
+        elif hex_header.startswith("000000") and "66747970" in hex_header:  # mp4 - ftyp (mp4 and variants)
             data_modality, data_encoding, mime_type, file_extension = "Video", "mp4", "video/mp4", "mp4"
+        elif hex_header.startswith("4f676753"):  # ogg - OggS (generic, no vorbis/opus detected)
+            data_modality, data_encoding, mime_type, file_extension = "Video", "ogg", "video/ogg", "ogg"
+        elif hex_header.startswith("1a45dfa3") and "7765626d" in hex_header:  # webm - EBML + webm doctype
+            data_modality, data_encoding, mime_type, file_extension = "Video", "webm", "video/webm", "webm"
+
+        # File (zip-based formats: jit, pt, zip - all return bin)
+        elif hex_header.startswith("504b0304"):  # `.pt` files have a zip header
+            data_modality, data_encoding, mime_type, file_extension = "File", "bin", "application/octet-stream", "bin"
+
+        # Text (must be last - uses fallback decode detection)
         elif self.__is_utf16(header):
             data_modality, data_encoding, mime_type, file_extension = "Text", "utf16", "text/plain", "txt"
         elif self.__is_utf8(header):

--- a/norman_utils_external/file_utils.py
+++ b/norman_utils_external/file_utils.py
@@ -34,12 +34,9 @@ class FileUtils(metaclass=Singleton):
                 "file_extension": "bin",
                 "Content-Type": "application/octet-stream"
             }
-        return self.__get_file_type_from_header(header)
+        return self.get_file_type_from_header(header)
 
-    def get_file_type_from_bytes(self, content: bytes):
-        return self.__get_file_type_from_header(content)
-
-    def __get_file_type_from_header(self, header: bytes):
+    def get_file_type_from_header(self, header: bytes):
         hex_header = header.hex()
 
         # Audio (alphabetical: aac, ac3, flac, mp3, opus, vorbis, wav)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ authors = [
 requires-python = ">=3.9"
 license = {text = "Apache-2.0"}
 dependencies = [
-    "cryptography==45.0.7",
-    "filetype==1.2.0",
+    "cryptography==45.0.7"
 ]
 
 [tools.setuptools]


### PR DESCRIPTION
Add text modality support to FileSanitizer with UTF-8 validation. Fix NoneType error when filetype.guess returns None for unsupported formats.